### PR TITLE
Composables should be side-effect free

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.canerture.valorantcompose"
         minSdk 23
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 101
+        versionName "1.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.canerture.valorantcompose"
         minSdk 23
         targetSdk 32
-        versionCode 101
-        versionName "1.0.1"
+        versionCode 102
+        versionName "1.0.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/canerture/valorantcompose/common/Constants.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/common/Constants.kt
@@ -8,4 +8,8 @@ object Constants {
     const val CATEGORY_MAPS = "Maps"
     const val CATEGORY_WEAPONS = "Weapons"
     const val CATEGORY_COMPETITIVE_TIERS = "Tiers"
+
+    const val PARAM_AGENT_ID = "agentUuid"
+    const val PARAM_MAP_ID = "mapUuid"
+    const val PARAM_WEAPON_ID = "weaponUuid"
 }

--- a/app/src/main/java/com/canerture/valorantcompose/navigation/NavGraph.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/navigation/NavGraph.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
 import com.canerture.valorantcompose.presentation.agent.agentdetail.AgentDetailScreen
 import com.canerture.valorantcompose.presentation.agent.agents.AgentsScreen
 import com.canerture.valorantcompose.presentation.competitivetiers.CompetitiveTiersScreen
@@ -55,14 +53,8 @@ fun NavGraph(navController: NavHostController, paddingValues: PaddingValues) {
             )
         }
 
-        composable(route = "${Screen.AgentDetail.route}/{agentUuid}",
-            arguments = listOf(
-                navArgument("agentUuid") { type = NavType.StringType }
-            )
-        ) {
-            it.arguments?.getString("agentUuid")?.let { agentUuid ->
-                AgentDetailScreen(agentUuid)
-            }
+        composable(route = "${Screen.AgentDetail.route}/{agentUuid}") {
+            AgentDetailScreen()
         }
 
         composable(route = Screen.Maps.route) {
@@ -73,13 +65,8 @@ fun NavGraph(navController: NavHostController, paddingValues: PaddingValues) {
             )
         }
 
-        composable(route = "${Screen.MapDetail.route}/{mapUuid}",
-            arguments = listOf(
-                navArgument("mapUuid") { type = NavType.StringType }
-            )) {
-            it.arguments?.getString("mapUuid")?.let { mapUuid ->
-                MapDetailScreen(mapUuid)
-            }
+        composable(route = "${Screen.MapDetail.route}/{mapUuid}") {
+            MapDetailScreen()
         }
 
         composable(route = Screen.Weapons.route) {
@@ -90,13 +77,8 @@ fun NavGraph(navController: NavHostController, paddingValues: PaddingValues) {
             )
         }
 
-        composable(route = "${Screen.WeaponDetail.route}/{weaponUuid}",
-            arguments = listOf(
-                navArgument("weaponUuid") { type = NavType.StringType }
-            )) {
-            it.arguments?.getString("weaponUuid")?.let { weaponUuid ->
-                WeaponDetailScreen(weaponUuid)
-            }
+        composable(route = "${Screen.WeaponDetail.route}/{weaponUuid}") {
+            WeaponDetailScreen()
         }
 
         composable(route = Screen.CompetitiveTiers.route) {

--- a/app/src/main/java/com/canerture/valorantcompose/navigation/NavGraph.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/navigation/NavGraph.kt
@@ -29,7 +29,11 @@ fun NavGraph(navController: NavHostController, paddingValues: PaddingValues) {
         composable(route = Screen.Splash.route) {
             SplashScreen(
                 navigateToAgents = {
-                    navController.navigate(Screen.Agents.route)
+                    navController.navigate(Screen.Agents.route) {
+                        popUpTo(Screen.Splash.route) {
+                            inclusive = true
+                        }
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/agent/agentdetail/AgentDetailScreen.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/agent/agentdetail/AgentDetailScreen.kt
@@ -38,13 +38,8 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun AgentDetailScreen(
-    agentUuid: String,
     viewModel: AgentDetailViewModel = hiltViewModel()
 ) {
-
-    LaunchedEffect(key1 = true) {
-        viewModel.getAgentDetail(agentUuid)
-    }
 
     val state = viewModel.state.value
 

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/agent/agentdetail/AgentDetailViewModel.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/agent/agentdetail/AgentDetailViewModel.kt
@@ -2,8 +2,10 @@ package com.canerture.valorantcompose.presentation.agent.agentdetail
 
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.canerture.valorantcompose.common.Constants
 import com.canerture.valorantcompose.common.Resource
 import com.canerture.valorantcompose.domain.usecase.agents.GetAgentDetailUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,13 +15,20 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AgentDetailViewModel @Inject constructor(
-    private val getAgentDetailUseCase: GetAgentDetailUseCase
+    private val getAgentDetailUseCase: GetAgentDetailUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _state = mutableStateOf(AgentDetailState())
     val state: State<AgentDetailState> = _state
 
-    fun getAgentDetail(agentUuid: String) {
+    init {
+        savedStateHandle.get<String>(Constants.PARAM_AGENT_ID)?.let { agentId ->
+            getAgentDetail(agentId)
+        }
+    }
+
+    private fun getAgentDetail(agentUuid: String) {
         getAgentDetailUseCase(agentUuid).onEach { result ->
             when (result) {
                 is Resource.Success -> {

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/agent/agents/AgentsScreen.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/agent/agents/AgentsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,9 +20,6 @@ fun AgentsScreen(
     viewModel: AgentsViewModel = hiltViewModel(),
     navigateToAgentDetail: (String) -> Unit,
 ) {
-    LaunchedEffect(key1 = true) {
-        viewModel.getAgents()
-    }
 
     val state = viewModel.state.value
 

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/agent/agents/AgentsViewModel.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/agent/agents/AgentsViewModel.kt
@@ -19,7 +19,11 @@ class AgentsViewModel @Inject constructor(
     private val _state = mutableStateOf(AgentsState())
     val state: State<AgentsState> = _state
 
-    fun getAgents() {
+    init {
+        getAgents()
+    }
+
+    private fun getAgents() {
         getAgentsUseCase().onEach { result ->
             when (result) {
                 is Resource.Success -> {

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/competitivetiers/CompetitiveTiersScreen.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/competitivetiers/CompetitiveTiersScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -20,9 +19,6 @@ import com.canerture.valorantcompose.common.components.ErrorText
 fun CompetitiveTiersScreen(
     viewModel: CompetitiveTiersViewModel = hiltViewModel()
 ) {
-    LaunchedEffect(key1 = true) {
-        viewModel.getCompetitiveTiers()
-    }
 
     val state = viewModel.state.value
 

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/competitivetiers/CompetitiveTiersViewModel.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/competitivetiers/CompetitiveTiersViewModel.kt
@@ -19,7 +19,11 @@ class CompetitiveTiersViewModel @Inject constructor(
     private val _state = mutableStateOf(CompetitiveTiersState())
     val state: State<CompetitiveTiersState> = _state
 
-    fun getCompetitiveTiers() {
+    init {
+        getCompetitiveTiers()
+    }
+
+    private fun getCompetitiveTiers() {
         getCompetitiveTiersUseCase().onEach { result ->
             when (result) {
                 is Resource.Success -> {

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/map/mapdetail/MapDetailScreen.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/map/mapdetail/MapDetailScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,13 +20,8 @@ import com.skydoves.landscapist.glide.GlideImage
 
 @Composable
 fun MapDetailScreen(
-    mapUuid: String,
     viewModel: MapDetailViewModel = hiltViewModel()
 ) {
-
-    LaunchedEffect(key1 = true) {
-        viewModel.getMapDetail(mapUuid)
-    }
 
     val state = viewModel.state.value
 

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/map/mapdetail/MapDetailViewModel.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/map/mapdetail/MapDetailViewModel.kt
@@ -2,8 +2,10 @@ package com.canerture.valorantcompose.presentation.map.mapdetail
 
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.canerture.valorantcompose.common.Constants
 import com.canerture.valorantcompose.common.Resource
 import com.canerture.valorantcompose.domain.usecase.maps.GetMapDetailUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,13 +15,20 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MapDetailViewModel @Inject constructor(
-    private val getMapDetailUseCase: GetMapDetailUseCase
+    private val getMapDetailUseCase: GetMapDetailUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _state = mutableStateOf(MapDetailState())
     val state: State<MapDetailState> = _state
 
-    fun getMapDetail(mapUuid: String) {
+    init {
+        savedStateHandle.get<String>(Constants.PARAM_MAP_ID)?.let { mapId ->
+            getMapDetail(mapId)
+        }
+    }
+
+    private fun getMapDetail(mapUuid: String) {
         getMapDetailUseCase(mapUuid).onEach { result ->
             when (result) {
                 is Resource.Success -> {

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/map/maps/MapsScreen.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/map/maps/MapsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,9 +20,6 @@ fun MapsScreen(
     viewModel: MapsViewModel = hiltViewModel(),
     navigateToMapDetail: (String) -> Unit
 ) {
-    LaunchedEffect(key1 = true) {
-        viewModel.getMaps()
-    }
 
     val state = viewModel.state.value
 

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/map/maps/MapsViewModel.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/map/maps/MapsViewModel.kt
@@ -19,7 +19,11 @@ class MapsViewModel @Inject constructor(
     private val _state = mutableStateOf(MapsState())
     val state: State<MapsState> = _state
 
-    fun getMaps() {
+    init {
+        getMaps()
+    }
+
+    private fun getMaps() {
         getMapsUseCase().onEach { result ->
             when (result) {
                 is Resource.Success -> {

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/weapon/weapondetail/WeaponDetailScreen.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/weapon/weapondetail/WeaponDetailScreen.kt
@@ -36,13 +36,8 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun WeaponDetailScreen(
-    weaponUuid: String,
     viewModel: WeaponDetailViewModel = hiltViewModel()
 ) {
-
-    LaunchedEffect(key1 = true) {
-        viewModel.getWeaponDetail(weaponUuid)
-    }
 
     val state = viewModel.state.value
 

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/weapon/weapondetail/WeaponDetailViewModel.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/weapon/weapondetail/WeaponDetailViewModel.kt
@@ -2,8 +2,10 @@ package com.canerture.valorantcompose.presentation.weapon.weapondetail
 
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.canerture.valorantcompose.common.Constants
 import com.canerture.valorantcompose.common.Resource
 import com.canerture.valorantcompose.domain.usecase.weapons.GetWeaponDetailUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,13 +15,20 @@ import javax.inject.Inject
 
 @HiltViewModel
 class WeaponDetailViewModel @Inject constructor(
-    private val getWeaponDetailUseCase: GetWeaponDetailUseCase
+    private val getWeaponDetailUseCase: GetWeaponDetailUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _state = mutableStateOf(WeaponDetailState())
     val state: State<WeaponDetailState> = _state
 
-    fun getWeaponDetail(weaponUuid: String) {
+    init {
+        savedStateHandle.get<String>(Constants.PARAM_WEAPON_ID)?.let { weaponId ->
+            getWeaponDetail(weaponId)
+        }
+    }
+
+    private fun getWeaponDetail(weaponUuid: String) {
         getWeaponDetailUseCase.getWeaponDetailByUuid(weaponUuid).onEach { result ->
             when (result) {
                 is Resource.Success -> {

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/weapon/weapons/WeaponsScreen.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/weapon/weapons/WeaponsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,9 +20,6 @@ fun WeaponsScreen(
     viewModel: WeaponsViewModel = hiltViewModel(),
     navigateToWeaponDetail: (String) -> Unit
 ) {
-    LaunchedEffect(key1 = true) {
-        viewModel.getWeapons()
-    }
 
     val state = viewModel.state.value
 

--- a/app/src/main/java/com/canerture/valorantcompose/presentation/weapon/weapons/WeaponsViewModel.kt
+++ b/app/src/main/java/com/canerture/valorantcompose/presentation/weapon/weapons/WeaponsViewModel.kt
@@ -19,7 +19,11 @@ class WeaponsViewModel @Inject constructor(
     private val _state = mutableStateOf(WeaponsState())
     val state: State<WeaponsState> = _state
 
-    fun getWeapons() {
+    init {
+        getWeapons()
+    }
+
+    private fun getWeapons() {
         getWeaponsUseCase().onEach { result ->
             when (result) {
                 is Resource.Success -> {


### PR DESCRIPTION
- Composables should be side-effect free, if it is possible. You can use `init{}` blocks to execute usecases when viewmodel is instantiated. [https://developer.android.com/jetpack/compose/side-effects](url)
- When back pressed from any screen, going back to splash screen bug fixed